### PR TITLE
Fixing #13003

### DIFF
--- a/_build/transport.core.php
+++ b/_build/transport.core.php
@@ -517,11 +517,6 @@ $attributes['resolve'][] = array (
 );
 $attributes['resolve'][] = array (
     'type' => 'file',
-    'source' => MODX_BASE_PATH . 'manager/cache.manifest.php',
-    'target' => "return MODX_MANAGER_PATH;",
-);
-$attributes['resolve'][] = array (
-    'type' => 'file',
     'source' => MODX_BASE_PATH . 'manager/index.php',
     'target' => "return MODX_MANAGER_PATH;",
 );


### PR DESCRIPTION
### What does it do?
Remove required cache.manifest.php from build script.

### Why is it needed?
The file was removed during merging #12985

### Related issue(s)/PR(s)
#13003